### PR TITLE
fix: hasMinimumAmount from boolean to string

### DIFF
--- a/swagger-apis/metrics-collection-platform/2.1.0.yml
+++ b/swagger-apis/metrics-collection-platform/2.1.0.yml
@@ -2953,7 +2953,7 @@ components:
         hasMinimumAmount:
           description: |
             Valida se possui o valor mínimo definido pelo usuário recebedor​.
-          type: boolean
+          type: string
           enum:
             - "TRUE"
             - "FALSE"


### PR DESCRIPTION
Este campo, assim como todos os outros do additionalinfo devem ser strings, portanto necessitou de ajustes para constar como string.